### PR TITLE
Add standalone url field to fx2 setup.py

### DIFF
--- a/software/setup.py
+++ b/software/setup.py
@@ -78,6 +78,7 @@ See the documentation for details.
         "bdist_egg": Fx2BdistEgg,
         "sdist": Fx2Sdist,
     },
+    url="https://libfx2.readthedocs.io/",
     project_urls={
         "Documentation": "https://libfx2.readthedocs.io/",
         "Source Code": "https://github.com/whitequark/libfx2",


### PR DESCRIPTION
This should add a visible homepage link to pypi sidebar [1] on next
release upload.

[1]:https://pypi.org/project/fx2/