### PR TITLE
fx2.format: Ignore record type 05 in input

### DIFF
--- a/software/fx2/format.py
+++ b/software/fx2/format.py
@@ -234,6 +234,9 @@ def input_data(file_or_data, fmt="auto", offset=0):
                 else:
                     assert False
 
+            elif rectype == 0x05:
+                pass
+
             elif rectype == 0x00:
                 recoff = (recoffh << 8) | recoffl
                 if resoff + len(resbuf) == recoff:


### PR DESCRIPTION
I'm using https://github.com/GlasgowEmbedded/glasgow/pull/185 to program some CC2530's with the glasgow.
The IAR compiler for those ICs generates a ihex file that contains a 0x05 record at the end to indicate the restart address.

Because that applet makes use of the ihex input parser in libfx2, this PR is here.

Record 0x05 is defined as follows https://en.wikipedia.org/wiki/Intel_HEX#Record_types

05 | Start Linear Address | The byte count is always 04, the address field is 0000.  The four data bytes represent a 32-bit address value (big-endian). In  the case of CPUs that support it, this 32-bit address is the starting  execution address).
-- | -- | --
