### PR TITLE
Fix fx2tool --bootloader

### DIFF
--- a/software/fx2/fx2tool.py
+++ b/software/fx2/fx2tool.py
@@ -349,7 +349,7 @@ def main():
         if device is not None:
             if args.bootloader:
                 bootloader_ihex = os.path.join(resource_dir, "boot-cypress.ihex")
-                device.load_ram(input_data(open(bootloader_ihex)))
+                device.load_ram(input_data(open(bootloader_ihex, "rb")))
             elif args.stage2:
                 device.load_ram(input_data(args.stage2))
 


### PR DESCRIPTION
Without this fix, 'fx2load --bootloader' will die with the error message "read of closed file".