### PR TITLE
compatibility with sdcc 4.3.0: emit build/.d files through a separate command

### DIFF
--- a/firmware/library/fx2rules.mk
+++ b/firmware/library/fx2rules.mk
@@ -36,7 +36,8 @@ $(LIBFX2)/.stamp: $(wildcard $(LIBFX2)/*.c $(LIBFX2)/*.asm $(LIBFX2)/include/*.h
 -include build/*.d
 build/%.rel: %.c
 	@mkdir -p $(dir $@)
-	$(SDCC) -Wp,-MQ,$@,-MMD,build/$*.d -c -o $@ $<
+	$(SDCC) -MQ $@ -MMD -o build/$*.d $<
+	$(SDCC) -c -o $@ $<
 
 build/%.rel: %.asm
 	@mkdir -p $(dir $@)


### PR DESCRIPTION
Implementing the two-pass solution mentioned [here](https://sourceforge.net/p/sdcc/mailman/message/37851121/) as the one originally implemented as part of #13 wasn't accepted.

I am unsure whether this should be a separate rule or part of the previously existing one, so please tell me whatever is more preferred here.

I've tested this on sdcc 4.2.0 and 4.3.0 and in both cases, compilation happens without error, and build/*.d files contain expected contents. Hopefully, I haven't missed something.

Related: https://github.com/whitequark/libfx2/issues/11#issuecomment-1910613239