### PR TITLE
Make it look for 'sdcc-sdcc' and 'sdcc-sdas8051' executables too

### DIFF
--- a/firmware/library/Makefile
+++ b/firmware/library/Makefile
@@ -1,6 +1,8 @@
-SDCC  = sdcc -mmcs51 --std-sdcc99 -Iinclude $(CFLAGS)
-SDAS  = sdas8051 -plo
-SDAR ?= sdar rc
+include sdcc.mk
+
+SDCC  = $(SDCC_EXECUTABLE) -mmcs51 --std-sdcc99 -Iinclude $(CFLAGS)
+SDAS  = $(SDAS_EXECUTABLE) -plo
+SDAR ?= $(SDAR_EXECUTABLE) rc
 
 # core interrupts
 DEFISRS  = \

--- a/firmware/library/fx2conf.mk
+++ b/firmware/library/fx2conf.mk
@@ -31,6 +31,8 @@ ifeq ($(V),1)
 SDCCFLAGS += -V
 endif
 
-SDCC       = sdcc -mmcs51 $(SDCCFLAGS)
-SDAS       = sdas8051 -plo
+include $(LIBFX2)/sdcc.mk
+
+SDCC       = $(SDCC_EXECUTABLE) -mmcs51 $(SDCCFLAGS)
+SDAS       = $(SDAS_EXECUTABLE) -plo
 FX2LOAD    = python3 -m fx2.fx2tool -d $(VID):$(PID) load

--- a/firmware/library/sdcc.mk
+++ b/firmware/library/sdcc.mk
@@ -1,0 +1,35 @@
+ifeq (,$(SDCC_EXECUTABLE))
+  ifeq (, $(shell command -v sdcc))
+    ifeq (, $(shell command -v sdcc-sdcc))
+      $(error "No sdcc executable found. Consider installing the sdcc package, or specifying an alternate executable with SDCC_EXECTUABLE")
+    else
+      SDCC_EXECUTABLE = sdcc-sdcc
+    endif
+  else
+    SDCC_EXECUTABLE = sdcc
+  endif
+endif
+
+ifeq (,$(SDAS_EXECUTABLE))
+  ifeq (, $(shell command -v sdas8051))
+    ifeq (, $(shell command -v sdcc-sdas8051))
+      $(error "No sdas8051 executable found. Consider installing the sdcc package, or specifying an alternate executable with SDAS_EXECTUABLE")
+    else
+      SDAS_EXECUTABLE = sdcc-sdas8051
+    endif
+  else
+    SDAS_EXECUTABLE = sdas8051
+  endif
+endif
+
+ifeq (,$(SDAR_EXECUTABLE))
+  ifeq (, $(shell command -v sdar))
+    ifeq (, $(shell command -v sdcc-sdar))
+      $(error "No sdar executable found. Consider installing the sdcc package, or specifying an alternate executable with SDAR_EXECTUABLE")
+    else
+      SDAR_EXECUTABLE = sdcc-sdar
+    endif
+  else
+    SDAR_EXECUTABLE = sdar
+  endif
+endif


### PR DESCRIPTION
This is the name of the executables on fedora (tested on fedora:latest docker container)