### PR TITLE
Add SETUP_EP0_OUT_BUF(), to be used for OUT control transfers.

### DIFF
--- a/examples/boot-dfu-spiflash/Makefile
+++ b/examples/boot-dfu-spiflash/Makefile
@@ -2,5 +2,8 @@ TARGET    = boot-dfu-spiflash
 LIBRARIES = fx2 fx2usb fx2dfu fx2isrs
 MODEL     = medium
 
+CODE_SIZE ?= 0x3c00
+XRAM_SIZE ?= 0x0400
+
 LIBFX2  = ../../firmware/library
 include $(LIBFX2)/fx2rules.mk

--- a/examples/boot-dfu-spiflash/main.c
+++ b/examples/boot-dfu-spiflash/main.c
@@ -268,7 +268,7 @@ usb_dfu_iface_state_t usb_dfu_iface_state = {
 void handle_usb_get_interface(uint8_t interface) {
   if(interface == 0) {
     EP0BUF[0] = dfu_alt_setting;
-    SETUP_EP0_BUF(1);
+    SETUP_EP0_IN_BUF(1);
     return;
   }
   STALL_EP0();

--- a/examples/boot-uf2-dfu/Makefile
+++ b/examples/boot-uf2-dfu/Makefile
@@ -2,5 +2,8 @@ TARGET    = boot-uf2-dfu
 LIBRARIES = fx2 fx2usb fx2dfu fx2usbmassstor fx2uf2 fx2isrs
 MODEL     = medium
 
+CODE_SIZE ?= 0x3c00
+XRAM_SIZE ?= 0x0400
+
 LIBFX2  = ../../firmware/library
 include $(LIBFX2)/fx2rules.mk

--- a/examples/cdc-acm/main.c
+++ b/examples/cdc-acm/main.c
@@ -199,7 +199,8 @@ void handle_usb_setup(__xdata struct usb_req_setup *req) {
   if(req->bmRequestType == (USB_RECIP_IFACE|USB_TYPE_CLASS|USB_DIR_OUT) &&
      req->bRequest == USB_CDC_PSTN_REQ_SET_LINE_CODING &&
      req->wIndex == 0 && req->wLength == 7) {
-    SETUP_EP0_BUF(0);
+    SETUP_EP0_OUT_BUF();
+    ACK_EP0(); // Since we're throwing away the buffer, it's okay to immediately just ACK it.
     return;
   }
 

--- a/examples/cdc-acm/main.c
+++ b/examples/cdc-acm/main.c
@@ -190,7 +190,7 @@ void handle_usb_setup(__xdata struct usb_req_setup *req) {
     line_coding->bCharFormat = USB_CDC_REQ_LINE_CODING_STOP_BITS_1;
     line_coding->bParityType = USB_CDC_REQ_LINE_CODING_PARITY_NONE;
     line_coding->bDataBits = 8;
-    SETUP_EP0_BUF(sizeof(struct usb_cdc_req_line_coding));
+    SETUP_EP0_IN_BUF(sizeof(struct usb_cdc_req_line_coding));
     return;
   }
 

--- a/firmware/boot-cypress/main.c
+++ b/firmware/boot-cypress/main.c
@@ -145,7 +145,7 @@ void handle_pending_usb_setup(void) {
           STALL_EP0();
           break;
         }
-        SETUP_EP0_BUF(len);
+        SETUP_EP0_IN_BUF(len);
       } else {
         SETUP_EP0_BUF(0);
         while(EP0CS & _BUSY);
@@ -177,7 +177,7 @@ void handle_pending_usb_setup(void) {
       if(arg_read) {
         while(EP0CS & _BUSY);
         xmemcpy(EP0BUF, (__xdata void *)arg_addr, len);
-        SETUP_EP0_BUF(len);
+        SETUP_EP0_IN_BUF(len);
       } else {
         SETUP_EP0_BUF(0);
         while(EP0CS & _BUSY);

--- a/firmware/boot-cypress/main.c
+++ b/firmware/boot-cypress/main.c
@@ -147,13 +147,14 @@ void handle_pending_usb_setup(void) {
         }
         SETUP_EP0_IN_BUF(len);
       } else {
-        SETUP_EP0_BUF(0);
+        SETUP_EP0_OUT_BUF();
         while(EP0CS & _BUSY);
         if(!eeprom_write(arg_chip, arg_addr, EP0BUF, len, arg_dbyte, page_size,
                          /*timeout=*/166)) {
           STALL_EP0();
           break;
         }
+        ACK_EP0();
       }
 
       arg_len  -= len;
@@ -179,9 +180,10 @@ void handle_pending_usb_setup(void) {
         xmemcpy(EP0BUF, (__xdata void *)arg_addr, len);
         SETUP_EP0_IN_BUF(len);
       } else {
-        SETUP_EP0_BUF(0);
+        SETUP_EP0_OUT_BUF();
         while(EP0CS & _BUSY);
         xmemcpy((__xdata void *)arg_addr, EP0BUF, arg_len);
+        ACK_EP0();
       }
 
       arg_len  -= len;

--- a/firmware/boot-dfu/Makefile
+++ b/firmware/boot-dfu/Makefile
@@ -2,5 +2,8 @@ TARGET    = boot-dfu
 LIBRARIES = fx2 fx2usb fx2dfu fx2isrs
 MODEL     = small
 
+CODE_SIZE ?= 0x3c00
+XRAM_SIZE ?= 0x0400
+
 LIBFX2  = ../library
 include $(LIBFX2)/fx2rules.mk

--- a/firmware/library/defusbgetconfig.c
+++ b/firmware/library/defusbgetconfig.c
@@ -2,5 +2,5 @@
 
 void handle_usb_get_configuration(void) {
   EP0BUF[0] = usb_config_value;
-  SETUP_EP0_BUF(1);
+  SETUP_EP0_IN_BUF(1);
 }

--- a/firmware/library/defusbgetiface.c
+++ b/firmware/library/defusbgetiface.c
@@ -3,5 +3,5 @@
 void handle_usb_get_interface(uint8_t interface) {
   interface;
   EP0BUF[0] = 0;
-  SETUP_EP0_BUF(1);
+  SETUP_EP0_IN_BUF(1);
 }

--- a/firmware/library/include/fx2usb.h
+++ b/firmware/library/include/fx2usb.h
@@ -68,13 +68,19 @@ void usb_init(bool disconnect);
   * For OUT control transfers, please use one or more `SETUP_EP0_OUT_BUF()`,
   * followed by a single `ACK_EP0()` call, but only after all data has been
   * processed from `EP0BUF`.
+  *
+  * If one desires to use the deprecated SETUP_EP0_BUF, then it can be
+  * re-enabled with:
+  * `CFLAGS=-DSETUP_EP0_BUF_is_deprecated_use_SETUP_EP0_IN_BUF_or_SETUP_EP0_OUT_BUF_instead=1`
   */
 #define SETUP_EP0_BUF(length) \
   do { \
-    SUDPTRCTL = _SDPAUTO; \
-    EP0BCH = 0; \
-    EP0BCL = length; \
-    EP0CS = _HSNAK; \
+    if (SETUP_EP0_BUF_is_deprecated_use_SETUP_EP0_IN_BUF_or_SETUP_EP0_OUT_BUF_instead) { \
+      SUDPTRCTL = _SDPAUTO; \
+      EP0BCH = 0; \
+      EP0BCL = length; \
+      EP0CS = _HSNAK; \
+    } \
   } while(0)
 
 /**

--- a/firmware/library/include/fx2usb.h
+++ b/firmware/library/include/fx2usb.h
@@ -53,15 +53,53 @@ void usb_init(bool disconnect);
   } while(0)
 
 /**
- * Configure EP0 for an IN or OUT transfer from or to `EP0BUF`.
- * For an OUT transfer, specify `length` as `0`.
- */
+  * This call is deprecated.
+  *
+  * Old documentation said:
+  * Configure EP0 for an IN or OUT transfer from or to `EP0BUF`.
+  * For an OUT transfer, specify `length` as `0`.
+  *
+  * However using `SETUP_EP0_BUF(0)` for OUT transfers will expose a
+  * race condition when the host is too eager to send more control
+  * transfers.
+  *
+  * For IN control transfers, please use `SETUP_EP0_IN_BUF(length)` instead.
+  *
+  * For OUT control transfers, please use one or more `SETUP_EP0_OUT_BUF()`,
+  * followed by a single `ACK_EP0()` call, but only after all data has been
+  * processed from `EP0BUF`.
+  */
 #define SETUP_EP0_BUF(length) \
   do { \
     SUDPTRCTL = _SDPAUTO; \
     EP0BCH = 0; \
     EP0BCL = length; \
     EP0CS = _HSNAK; \
+  } while(0)
+
+/**
+ * Configure EP0 for an IN transfer from `EP0BUF`.
+ */
+#define SETUP_EP0_IN_BUF(length) \
+  do { \
+    SUDPTRCTL = _SDPAUTO; \
+    EP0BCH = 0; \
+    EP0BCL = length; \
+    EP0CS = _HSNAK; \
+  } while(0)
+
+/**
+ * Configure EP0 for an OUT transfer from `EP0BUF`.
+ *
+ * For OUT transfers please use one or more calls to
+ * `SETUP_EP0_OUT_BUF()` followed by a single call to `ACK_EP0()`.
+ * Do not call `ACK_EP0()` before processing all pending data in `EP0BUF`
+ */
+#define SETUP_EP0_OUT_BUF() \
+  do { \
+    SUDPTRCTL = _SDPAUTO; \
+    EP0BCH = 0; \
+    EP0BCL = 0; \
   } while(0)
 
 /**

--- a/firmware/library/usb.c
+++ b/firmware/library/usb.c
@@ -113,13 +113,13 @@ __endasm;
     EP0BUF[0] = (usb_self_powered  << 0) |
                 (usb_remote_wakeup << 1);
     EP0BUF[1] = 0;
-    SETUP_EP0_BUF(2);
+    SETUP_EP0_IN_BUF(2);
     // Get Status - Interface
   } else if(req->bmRequestType == (USB_RECIP_IFACE|USB_TYPE_STANDARD|USB_DIR_IN) &&
             req->bRequest == USB_REQ_GET_STATUS) {
     EP0BUF[0] = 0;
     EP0BUF[1] = 0;
-    SETUP_EP0_BUF(2);
+    SETUP_EP0_IN_BUF(2);
     // Set Feature - Endpoint
     // Clear Feature - Endpoint
   } else if(req->bmRequestType == (USB_RECIP_ENDPT|USB_TYPE_STANDARD|USB_DIR_OUT) &&
@@ -147,7 +147,7 @@ __endasm;
     if(EPnCS != 0) {
       EP0BUF[0] = ((*EPnCS & _STALL) != 0);
       EP0BUF[1] = 0;
-      SETUP_EP0_BUF(2);
+      SETUP_EP0_IN_BUF(2);
     }
   } else {
     handle_usb_setup(req);

--- a/firmware/library/usbdfu.c
+++ b/firmware/library/usbdfu.c
@@ -23,7 +23,7 @@ bool usb_dfu_setup(usb_dfu_iface_state_t *dfu, __xdata struct usb_req_setup *req
       req->bRequest == USB_DFU_REQ_GETSTATE && req->wValue == 0 &&
       req->wLength == sizeof(uint8_t)) {
     EP0BUF[0] = dfu->state;
-    SETUP_EP0_BUF(1);
+    SETUP_EP0_IN_BUF(1);
     return true;
   }
 
@@ -55,7 +55,7 @@ bool usb_dfu_setup(usb_dfu_iface_state_t *dfu, __xdata struct usb_req_setup *req
     status->bwPollTimeoutHigh = 0;
     status->bState = dfu->state;
     status->iString = 0;
-    SETUP_EP0_BUF(sizeof(struct usb_dfu_req_get_status));
+    SETUP_EP0_IN_BUF(sizeof(struct usb_dfu_req_get_status));
     return true;
   }
 
@@ -139,7 +139,7 @@ void usb_dfu_setup_deferred(usb_dfu_iface_state_t *dfu) {
       uint16_t length = dfu->length;
       dfu->status = dfu->firmware_upload(dfu->offset, &EP0BUF[0], &dfu->length);
       if(dfu->status == USB_DFU_STATUS_OK) {
-        SETUP_EP0_BUF(dfu->length);
+        SETUP_EP0_IN_BUF(dfu->length);
         if(dfu->length < length) {
           dfu->state = USB_DFU_STATE_dfuIDLE;
         }

--- a/firmware/library/usbmassstor.c
+++ b/firmware/library/usbmassstor.c
@@ -18,7 +18,7 @@ bool usb_mass_storage_bbb_setup(usb_mass_storage_bbb_state_t *state,
      request->bRequest == USB_REQ_MASS_STORAGE_GET_MAX_LUN &&
      request->wValue == 0 && request->wIndex == state->interface && request->wLength == 1) {
     EP0BUF[0] = state->max_lun;
-    SETUP_EP0_BUF(1);
+    SETUP_EP0_IN_BUF(1);
     return true;
   }
 


### PR DESCRIPTION
When processing OUT control transfers, the EP0 buffer is armed when wriging EP0BCL, while SDPAUTO is high. At this stage it's not necessary to set HSNAK, because that bit has an effect on the status stage, not on the data stage.

Beyond it being not necessary to write HSNAK early, it introduces a race condition, because the host sees the status stage complete early, before we have fully processed the content of EP0BUF, and as such it thinks it can send more control transfers. If the host actually sends more control transfers, then EP0BUF might be overwritten before we have completed processing EP0BUF, and this can cause data corruption.

The clean way to handle this, is to force the host to wait in the status stage until we have fully processed the EP0BUF, by NAK-ink the status stage. This does not mean that the packets in the Data stage will be NAK'd because, that is controlled by whether the buffer is armed or not.

Firmware-wise the new recommended way to the OUT control transfers is:

```c
for (each_expected_packet) {
    SETUP_EP0_OUT_BUF();
    handle_packet(EP0BUF, EP0BCL);
      // EP0BCL will have the size of the received packet
}
ACK_EP0();
```

That is: only call `ACK_EP0()`, which clears HSNAK by writing 1 to it, after we know it's safe to overwrite EP0BUF.

Note: a simple way to reproduce the issue when not following this procedure, is to run:

```bash
while true; do lsusb -v -d $(DEVICE_VID):$(DEVICE_PID) > /dev/null; done
```

In a terminal. (replacing DEVICE_VID/DEVICE_PID with correct values) While this loop is running, we expected most applications doing control out transfers with the old method to become unusable.

Technically speaking a single run of `lsusb` could even cause trouble if it happes at the wrong time, and I think this could be triggered in other situations as well, this is just the easiest way to reproduce the problem.