### PR TITLE
fix potential race condition in boot-cypress

### DIFF
--- a/firmware/boot-cypress/main.c
+++ b/firmware/boot-cypress/main.c
@@ -147,13 +147,14 @@ void handle_pending_usb_setup(void) {
         }
         SETUP_EP0_BUF(len);
       } else {
-        SETUP_EP0_BUF(0);
+        SETUP_EP0_OUT_BUF();
         while(EP0CS & _BUSY);
         if(!eeprom_write(arg_chip, arg_addr, EP0BUF, len, arg_dbyte, page_size,
                          /*timeout=*/166)) {
           STALL_EP0();
           break;
         }
+        ACK_EP0();
       }
 
       arg_len  -= len;
@@ -179,9 +180,10 @@ void handle_pending_usb_setup(void) {
         xmemcpy(EP0BUF, (__xdata void *)arg_addr, len);
         SETUP_EP0_BUF(len);
       } else {
-        SETUP_EP0_BUF(0);
+        SETUP_EP0_OUT_BUF();
         while(EP0CS & _BUSY);
         xmemcpy((__xdata void *)arg_addr, EP0BUF, arg_len);
+        ACK_EP0();
       }
 
       arg_len  -= len;


### PR DESCRIPTION
This PR depends on PR #18
**IMPORTANT: I have not tested this change,**
Note that I have tested similar changes in glasgow firmware, with success (will send a PR for that soon).

Note that this also potentially fixes any errors going unnoticed.
If we set HSNAK when we arm the buffer, the host will complete its status stage as soon as it sends the data stage, and will not wait for `eeprom_write` to finish. The `STALL_EP0()` call that we execute on line 154, will not have an effect, because the following setup packet will clear it (this is how the FX2 works), so this error would go undetected by the host!

Note that this change should still be tested before being merged, because before this change,
the firmware was not sensitive to potential spurious errors returned by eeprom_write.
If `eeprom_write` had a spurious errors problem, then this PR could introduce a regression,
so I suggest not merging this PR without testing it first.

Note that `STALL_EP0()` already sets `HSNAK`, so it's not necessary to call `ACK_EP0();` on failure.
