### PR TITLE
57600 -> 38400 baud change

### DIFF
--- a/examples/printf/main.c
+++ b/examples/printf/main.c
@@ -2,17 +2,19 @@
 #include <fx2debug.h>
 #include <stdio.h>
 
-DEFINE_DEBUG_PUTCHAR_FN(PA0, 57600)
+DEFINE_DEBUG_PUTCHAR_FN(PA0, 38400)
 
 int main(void) {
-  // Any of these will work at 57600 baud:
-  CPUCS = 0;
-  // CPUCS = _CLKSPD0;
-  // CPUCS = _CLKSPD1;
+  // Any of these will work at 38400 baud:
 
   OEA = (1U<<0);
   PA0 = 1;
 
-  printf("Hello, world!\n");
+  CPUCS = 0;
+  printf("Hello, world at 12MHz CPU clock!\r\n");
+  CPUCS = _CLKSPD0;
+  printf("Hello, world at 24MHz CPU clock!\r\n");
+  CPUCS = _CLKSPD1;
+  printf("Hello, world at 48MHz CPU clock!\r\n");
   while(1);
 }

--- a/examples/printf/main.c
+++ b/examples/printf/main.c
@@ -2,19 +2,28 @@
 #include <fx2debug.h>
 #include <stdio.h>
 
+
+// An example of how to push characters to a software UART on PA0.
+// As a test, the CLK speed is changed to check the code works for
+// a variety of frequencies.
+// 38400 likely works in all scenarios.  If you increase the baud
+// rate it may or may not work, but  
+
+
 DEFINE_DEBUG_PUTCHAR_FN(PA0, 38400)
 
 int main(void) {
-  // Any of these will work at 38400 baud:
-
   OEA = (1U<<0);
   PA0 = 1;
 
   CPUCS = 0;
   printf("Hello, world at 12MHz CPU clock!\r\n");
+  
   CPUCS = _CLKSPD0;
   printf("Hello, world at 24MHz CPU clock!\r\n");
+  
   CPUCS = _CLKSPD1;
   printf("Hello, world at 48MHz CPU clock!\r\n");
+  
   while(1);
 }

--- a/examples/printf/main.c
+++ b/examples/printf/main.c
@@ -6,8 +6,7 @@
 // An example of how to push characters to a software UART on PA0.
 // As a test, the CLK speed is changed to check the code works for
 // a variety of frequencies.
-// 38400 likely works in all scenarios.  If you increase the baud
-// rate it may or may not work, but  
+// 38400 likely works in all scenarios, YMMV with higher values.  
 
 
 DEFINE_DEBUG_PUTCHAR_FN(PA0, 38400)


### PR DESCRIPTION
Change clock speed for the example to 38400 baud to make it work with more adapters.
Add \r to print statements so CR happens in Minicom (probably won't hurt other programs)
Output with the clock speed at different frequencies chances are good *one* of them is going to work and the user can take it from there.